### PR TITLE
autoadjust line length to terminal width

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -14,6 +14,7 @@ WriteMakefile(
     'Params::Validate' => '0.74',
     'Sub::Exporter'    => 0.972, # generator name with \'name'
     'Test::More'       => 0,
+    'Term::ReadKey'    => 0,
   },
   dist                => { COMPRESS => 'gzip -9f', SUFFIX => 'gz', },
   clean               => { FILES => 'Getopt-Long-Descriptive-*' },

--- a/lib/Getopt/Long/Descriptive/Usage.pm
+++ b/lib/Getopt/Long/Descriptive/Usage.pm
@@ -5,6 +5,7 @@ use warnings;
 our $VERSION = '0.088';
 
 use List::Util qw(max);
+use Term::ReadKey qw(GetTerminalSize);
 
 =head1 NAME
 
@@ -46,6 +47,9 @@ sub new {
 
   my %copy;
   @copy{ @to_copy } = @$arg{ @to_copy };
+
+  my @terminal_size = GetTerminalSize();
+  $copy{terminal_width} = $terminal_size[0] ? $terminal_size[0] : 78;
 
   bless \%copy => $class;
 }
@@ -118,7 +122,7 @@ sub _split_description {
   my ($self, $length, $desc) = @_;
 
   # 8 for a tab, 2 for the space between option & desc;
-  my $max_length = 78 - ( $length + 8 + 2 );
+  my $max_length = $self->{terminal_width} - ( $length + 8 + 2 );
 
   return $desc if length $desc <= $max_length;
 


### PR DESCRIPTION
Most terminal windows we use are larger than 78 characters. The output of the usage description should use the available space. 

Change in Getopt::Long::Descriptive::Usage class:

Use Term::ReadKey to get the terminal width. Use 78 if GetTerminalSize
does not return a value.